### PR TITLE
additional log level mappings

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -22,13 +22,19 @@ SyslogPosix::log = (level, msg, meta, callback) ->
 
   # map common debug levels to valid posix syslog values
   syslogSeverity = level
-  if level == 'trace'
+  if level == 'trace' or level == 'debug'
     syslogSeverity = 'debug'
-  else if level == 'warn'
+  else if level == 'notice'
+    syslogSeverity = 'notice'
+  else if level == 'warn' or level == 'warning'
     syslogSeverity = 'warning'
   else if level == 'error'
     syslogSeverity = 'err'
-  else if level == 'fatal'
+  else if level == 'crit' or level == 'critical'
+    syslogSeverity = 'crit'
+  else if level == 'alert'
+    syslogSeverity = 'alert'
+  else if level == 'fatal' or level == 'emerg'
     syslogSeverity = 'emerg'
   else
     syslogSeverity = @unmapped


### PR DESCRIPTION
Hi, I'm not sure if this is the right way but in our code base we primarily use log.debug, log.info, log.warning and log.error and log.debug + log.warning gets mapped into the @unmapped setting (default info). Also I'm unsure what line 24 the assignment is good for since you always fall back to the @unmapped setting.
